### PR TITLE
Update chart selection for three chart types, include prediction & cleansing to charting, add prediction input date fields.

### DIFF
--- a/src/flaskr/home.py
+++ b/src/flaskr/home.py
@@ -7,6 +7,11 @@ sys.path.append("src")
 from sensors.sensor import Sensor
 from DataGeneration import DataGeneration
 
+import sys 
+sys.path.append("src")
+
+from sensors import sensor, Prediction, Cleanser
+
 from flaskr import app
 
 @app.route('/home', methods=['GET', 'POST'])
@@ -17,6 +22,9 @@ def home():
         field_id = request.form.get('field_id')
         start_date = request.form.get('start_date')
         time_increment = request.form.get('time_increment')
+        is_cleanse = request.form.get('cleanse')
+        is_predict = request.form.get('predict')
+        chart_type = request.form.get('chartType')  # Retrieve the selected chart type
 
         # Initialize DataGeneration with form data
         try:
@@ -28,8 +36,15 @@ def home():
             return redirect(url_for('home'))
         
         sensor = Sensor(name="Generated Sensor", description="Data from ThingSpeak", date_range=date_series, value=value_series)
+
+        if is_cleanse == "on":
+            sensor = Cleanser.cleanser(sensor, deviations=2)
+
+        if is_predict == "on":
+            print(is_predict)
+            sensor = Prediction.DataPrediction(sensor, datetime(2024, 3, 28))
+
         chart = Chart(sensor)
-        
-        return render_template('main/home.html', labels=chart.get_labels(), values=chart.get_values())
+        return render_template('main/home.html', labels=chart.get_labels(), values=chart.get_values(), chart_type=chart_type)
 
     return render_template('main/home.html')

--- a/src/flaskr/home.py
+++ b/src/flaskr/home.py
@@ -44,6 +44,10 @@ def home():
             print(is_predict)
             sensor = Prediction.DataPrediction(sensor, datetime(2024, 3, 28))
 
+        labels, values = sensor.process_data()
+        sensor.set_date_range(labels)
+        sensor.set_value(values)
+        
         chart = Chart(sensor)
         return render_template('main/home.html', labels=chart.get_labels(), values=chart.get_values(), chart_type=chart_type)
 

--- a/src/flaskr/home.py
+++ b/src/flaskr/home.py
@@ -24,6 +24,7 @@ def home():
         time_increment = request.form.get('time_increment')
         is_cleanse = request.form.get('cleanse')
         is_predict = request.form.get('predict')
+        prediction_date = request.form.get('prediction_date')
         chart_type = request.form.get('chartType')  # Retrieve the selected chart type
 
         # Initialize DataGeneration with form data
@@ -42,12 +43,12 @@ def home():
 
         if is_predict == "on":
             print(is_predict)
-            sensor = Prediction.DataPrediction(sensor, datetime(2024, 3, 28))
+            sensor = Prediction.DataPrediction(sensor, prediction_date)
 
         labels, values = sensor.process_data()
         sensor.set_date_range(labels)
         sensor.set_value(values)
-        
+
         chart = Chart(sensor)
         return render_template('main/home.html', labels=chart.get_labels(), values=chart.get_values(), chart_type=chart_type)
 

--- a/src/flaskr/home.py
+++ b/src/flaskr/home.py
@@ -26,7 +26,8 @@ def home():
         is_predict = request.form.get('predict')
         prediction_date = request.form.get('prediction_date')
         chart_type = request.form.get('chartType')  # Retrieve the selected chart type
-
+        stdDeviation = request.form.get('stdDeviation')
+        print(type(stdDeviation))
         # Initialize DataGeneration with form data
         try:
             data_gen = DataGeneration(channel_id, time_increment, field_id, start_date)
@@ -39,10 +40,10 @@ def home():
         sensor = Sensor(name="Generated Sensor", description="Data from ThingSpeak", date_range=date_series, value=value_series)
 
         if is_cleanse == "on":
-            sensor = Cleanser.cleanser(sensor, deviations=2)
+            stdDeviation = int(stdDeviation)
+            sensor = Cleanser.cleanser(sensor, deviations=stdDeviation)
 
         if is_predict == "on":
-            print(is_predict)
             sensor = Prediction.DataPrediction(sensor, prediction_date)
 
         labels, values = sensor.process_data()

--- a/src/flaskr/templates/main/home.html
+++ b/src/flaskr/templates/main/home.html
@@ -16,31 +16,83 @@
     <input type="text" name="start_date" id="start_date" placeholder="YYYY-MM-DD HH:MM:SS" pattern="\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}" required title="Date format should be YYYY-MM-DD HH:MM:SS">
     <label for="time_increment">Time Increment</label>
     <input name="time_increment" id="time_increment" required>
+
+    <label for="cleanse">Cleanse</label>
+    <input type="checkbox" name="cleanse" id="cleanse">
+    <label for="predict">Predict</label>
+    <input type="checkbox" name="predict" id="predict">
+
+    <label for="line_chart">Line Chart</label>
+    <input type="radio" name="chartType" id="line_chart" value="line_chart" required>
+    <label for="bar_chart">Bar Chart</label>
+    <input type="radio" name="chartType" id="bar_chart" value="bar_chart" required>
+    <label for="scatter_chart">Scatter Chart</label>
+    <input type="radio" name="chartType" id="scatter_chart" value="scatter_chart" required>
+
     <button type="submit">Get Data</button>
+
   </form>
 
-  <canvas id="lineChart" width="800" height="400"></canvas> <!-- Canvas element where the line chart will be drawn -->
+  <canvas id="Chart" width="800" height="400"></canvas> <!-- Canvas element where the line chart will be drawn -->
   <script>
     // Get the context of the canvas element we just defined
-    var ctx = document.getElementById('lineChart').getContext('2d');
+    var ctx = document.getElementById('Chart').getContext('2d');
+
+    if ("{{scatter_chart}}" == "scatter_chart") {
+      var scatterChart = new Chart(ctx, {
+        type: 'scatter', // Specifies that we want to create a scatter chart
+        data: {
+          labels: {{labels | safe}}, // Sets the labels for the x-axis from a template variable
+          datasets: [{ // Data for the bar chart including the dataset
+            label: 'Sensor', // Label for the dataset
+            data: {{values | safe}}, // The actual data points for the bar chart from a template variable
+            backgroundColor: 'rgba(255, 99, 132, 1)', // Color of the bars
+            borderWidth: 1 // Width of the bars
+          }]
+        },
+        options: {
+          responsive: true // Chart will not resize automatically when the container does
+        }
+      });
+    };
+
+    if ("{{chart_type}}" == "bar_chart") {
+      var barChart = new Chart(ctx, {
+        type: 'bar', // Specifies that we want to create a bar chart
+        data: {
+          labels: {{labels | safe}}, // Sets the labels for the x-axis from a template variable
+          datasets: [{ // Data for the bar chart including the dataset
+            label: 'Sensor', // Label for the dataset
+            data: {{values | safe}}, // The actual data points for the bar chart from a template variable
+            backgroundColor: 'rgba(255, 99, 132, 1)', // Color of the bars
+            borderWidth: 1 // Width of the bars
+          }]
+        },
+        options: {
+          responsive: true // Chart will not resize automatically when the container does
+        }
+      });
+    };
 
     // Creating a new Chart instance and passing the context
-    var lineChart = new Chart(ctx, {
-      type: 'line', // Specifies that we want to create a line chart
-      data: {
-        labels: {{labels | safe}}, // Sets the labels for the x-axis from a template variable
-        datasets: [{ // Data for the line chart including the dataset
-          label: 'Sensor', // Label for the dataset
-          data: {{values | safe}}, // The actual data points for the line chart from a template variable
-          borderColor: 'rgba(255, 99, 132, 1)', // Color of the line
-          fill: false, // Specifies that the area under the line should not be filled
-          borderWidth: 1 // Width of the line
-        }]
-      },
-      options: {
-        responsive: false // Chart will not resize automatically when the container does
-      }
-    });
+    if ("{{chart_type}}" == "line_chart") {
+      var lineChart = new Chart(ctx, {
+        type: 'line', // Specifies that we want to create a line chart
+        data: {
+          labels: {{labels | safe}}, // Sets the labels for the x-axis from a template variable
+          datasets: [{ // Data for the line chart including the dataset
+            label: 'Sensor', // Label for the dataset
+            data: {{values | safe}}, // The actual data points for the line chart from a template variable
+            borderColor: 'rgba(255, 99, 132, 1)', // Color of the line
+            fill: false, // Specifies that the area under the line should not be filled
+            borderWidth: 1 // Width of the line
+          }]
+        },
+        options: {
+          responsive: true // Chart will not resize automatically when the container does
+        }
+      });
+    };
   </script>
 
 {% endblock %}

--- a/src/flaskr/templates/main/home.html
+++ b/src/flaskr/templates/main/home.html
@@ -19,10 +19,21 @@
 
     <label for="cleanse">Cleanse</label>
     <input type="checkbox" name="cleanse" id="cleanse">
+    <label for="stdDeviation">Enter Standard Deviations To Cleanse</label>
+    <input type="number" name="stdDeviation" id="stdDeviation" min="1" step="1" placeholder="Positive integers only" required>
+    
     <label for="predict">Predict</label>
     <input type="checkbox" name="predict" id="predict">
     <label for="prediction_date">Prediction End Date</label>
-    <input type="text" name="prediction_date" id="prediction_date" placeholder="YYYY-MM-DD HH:MM:SS" pattern="\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}" required title="Date format should be YYYY-MM-DD HH:MM:SS">
+    <input type="text" name="prediction_date" id="prediction_date" placeholder="YYYY-MM-DD HH:MM:SS" pattern="\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}" title="Date format should be YYYY-MM-DD HH:MM:SS">
+
+    <script>
+      // JavaScript to make prediction_date required if predict is checked
+      document.getElementById('predict').addEventListener('change', function() {
+          var predictionDateInput = document.getElementById('prediction_date');
+          predictionDateInput.required = this.checked; // Set required based on checkbox
+      });
+    </script>
 
     <label for="line">Line Chart</label>
     <input type="radio" name="chartType" id="line" value="line" required>

--- a/src/flaskr/templates/main/home.html
+++ b/src/flaskr/templates/main/home.html
@@ -21,6 +21,8 @@
     <input type="checkbox" name="cleanse" id="cleanse">
     <label for="predict">Predict</label>
     <input type="checkbox" name="predict" id="predict">
+    <label for="prediction_date">Prediction End Date</label>
+    <input type="text" name="prediction_date" id="prediction_date" placeholder="YYYY-MM-DD HH:MM:SS" pattern="\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}" required title="Date format should be YYYY-MM-DD HH:MM:SS">
 
     <label for="line">Line Chart</label>
     <input type="radio" name="chartType" id="line" value="line" required>

--- a/src/flaskr/templates/main/home.html
+++ b/src/flaskr/templates/main/home.html
@@ -22,12 +22,12 @@
     <label for="predict">Predict</label>
     <input type="checkbox" name="predict" id="predict">
 
-    <label for="line_chart">Line Chart</label>
-    <input type="radio" name="chartType" id="line_chart" value="line_chart" required>
-    <label for="bar_chart">Bar Chart</label>
-    <input type="radio" name="chartType" id="bar_chart" value="bar_chart" required>
-    <label for="scatter_chart">Scatter Chart</label>
-    <input type="radio" name="chartType" id="scatter_chart" value="scatter_chart" required>
+    <label for="line">Line Chart</label>
+    <input type="radio" name="chartType" id="line" value="line" required>
+    <label for="bar">Bar Chart</label>
+    <input type="radio" name="chartType" id="bar" value="bar" required>
+    <label for="radar">Radar Chart</label>
+    <input type="radio" name="chartType" id="radar" value="radar" required>
 
     <button type="submit">Get Data</button>
 
@@ -38,61 +38,22 @@
     // Get the context of the canvas element we just defined
     var ctx = document.getElementById('Chart').getContext('2d');
 
-    if ("{{scatter_chart}}" == "scatter_chart") {
-      var scatterChart = new Chart(ctx, {
-        type: 'scatter', // Specifies that we want to create a scatter chart
-        data: {
-          labels: {{labels | safe}}, // Sets the labels for the x-axis from a template variable
-          datasets: [{ // Data for the bar chart including the dataset
-            label: 'Sensor', // Label for the dataset
-            data: {{values | safe}}, // The actual data points for the bar chart from a template variable
-            backgroundColor: 'rgba(255, 99, 132, 1)', // Color of the bars
-            borderWidth: 1 // Width of the bars
-          }]
-        },
-        options: {
-          responsive: true // Chart will not resize automatically when the container does
-        }
-      });
-    };
-
-    if ("{{chart_type}}" == "bar_chart") {
-      var barChart = new Chart(ctx, {
-        type: 'bar', // Specifies that we want to create a bar chart
-        data: {
-          labels: {{labels | safe}}, // Sets the labels for the x-axis from a template variable
-          datasets: [{ // Data for the bar chart including the dataset
-            label: 'Sensor', // Label for the dataset
-            data: {{values | safe}}, // The actual data points for the bar chart from a template variable
-            backgroundColor: 'rgba(255, 99, 132, 1)', // Color of the bars
-            borderWidth: 1 // Width of the bars
-          }]
-        },
-        options: {
-          responsive: true // Chart will not resize automatically when the container does
-        }
-      });
-    };
-
-    // Creating a new Chart instance and passing the context
-    if ("{{chart_type}}" == "line_chart") {
-      var lineChart = new Chart(ctx, {
-        type: 'line', // Specifies that we want to create a line chart
-        data: {
-          labels: {{labels | safe}}, // Sets the labels for the x-axis from a template variable
-          datasets: [{ // Data for the line chart including the dataset
-            label: 'Sensor', // Label for the dataset
-            data: {{values | safe}}, // The actual data points for the line chart from a template variable
-            borderColor: 'rgba(255, 99, 132, 1)', // Color of the line
-            fill: false, // Specifies that the area under the line should not be filled
-            borderWidth: 1 // Width of the line
-          }]
-        },
-        options: {
-          responsive: true // Chart will not resize automatically when the container does
-        }
-      });
-    };
+    var chart = new Chart(ctx, {
+      type: '{{chart_type}}', // Specifies that we want to create a scatter chart
+      data: {
+        labels: {{labels | safe}}, // Sets the labels for the x-axis from a template variable
+        datasets: [{ // Data for the bar chart including the dataset
+          label: 'Sensor', // Label for the dataset
+          data: {{values | safe}}, // The actual data points for the bar chart from a template variable
+          backgroundColor: 'rgba(255, 99, 132, 1)', // Color of the bars
+          fill: false,
+          borderWidth: 1 // Width of the bars
+        }]
+      },
+      options: {
+        responsive: true // Chart will not resize automatically when the container does
+      }
+    });
   </script>
 
 {% endblock %}

--- a/src/sensors/Prediction.py
+++ b/src/sensors/Prediction.py
@@ -3,7 +3,7 @@ from statsmodels.tsa.arima.model import ARIMA
 from statsmodels.tsa.statespace.sarimax import SARIMAX
 import pandas as pd
 from pmdarima import auto_arima
-import datetime as dt
+from datetime import datetime
 
 import sys 
 sys.path.append("src")
@@ -20,20 +20,19 @@ class DataPrediction(SensorDataDecorator):
         
         super().__init__(sensor)
 
-        if isinstance(prediction_end_date, dt):
-            self.start_date = prediction_end_date
+        if isinstance(prediction_end_date, datetime):
+            self.prediction_end_date = prediction_end_date
         else:
             # Try to parse the start_date string to datetime
             try:
-                self.start_date = dt.strptime(prediction_end_date, '%Y-%m-%d %H:%M:%S')
+                self.prediction_end_date = datetime.strptime(prediction_end_date, '%Y-%m-%d %H:%M:%S')
             except ValueError:
                 raise ValueError("start_date must be a datetime object or a string in the format 'YYYY-MM-DD HH:MM:SS'")
         
         self.X = sensor.get_date_range()
         self.prediction_intervals = self.X[-1] - self.X[-2]
         self.prediction_start_date = self.X[-1] + self.prediction_intervals
-        self.prediction_end_date = prediction_end_date
-
+        
         self.Y = sensor.get_value()
 
         self.X_future = None

--- a/src/sensors/Prediction.py
+++ b/src/sensors/Prediction.py
@@ -3,6 +3,7 @@ from statsmodels.tsa.arima.model import ARIMA
 from statsmodels.tsa.statespace.sarimax import SARIMAX
 import pandas as pd
 from pmdarima import auto_arima
+import datetime as dt
 
 import sys 
 sys.path.append("src")
@@ -18,6 +19,16 @@ class DataPrediction(SensorDataDecorator):
     def __init__(self, sensor, prediction_end_date):
         
         super().__init__(sensor)
+
+        if isinstance(prediction_end_date, dt):
+            self.start_date = prediction_end_date
+        else:
+            # Try to parse the start_date string to datetime
+            try:
+                self.start_date = dt.strptime(prediction_end_date, '%Y-%m-%d %H:%M:%S')
+            except ValueError:
+                raise ValueError("start_date must be a datetime object or a string in the format 'YYYY-MM-DD HH:MM:SS'")
+        
         self.X = sensor.get_date_range()
         self.prediction_intervals = self.X[-1] - self.X[-2]
         self.prediction_start_date = self.X[-1] + self.prediction_intervals

--- a/src/sensors/Prediction.py
+++ b/src/sensors/Prediction.py
@@ -73,5 +73,5 @@ class DataPrediction(SensorDataDecorator):
         self.predict()
         X_future = self.X_future
         Y_future = self.forcasted_values
-        return X, Y, X_future, Y_future
+        return X+X_future, Y+Y_future
 

--- a/src/sensors/sensor.py
+++ b/src/sensors/sensor.py
@@ -31,19 +31,12 @@ class Sensor(SensorDataProcessor):
 
     def set_value(self, new_value):
 
-        if len(new_value) != len(self.date_range):
-            raise ValueError("The length of the new value must be equal to the length of the date range")
-
         self.value = new_value
 
     def get_value(self):
         return self.value
 
     def set_date_range(self, new_date_range):
-
-        if len(new_date_range) != len(self.value):
-            raise ValueError("The length of the new date range must be equal to the length of the values")
-
         self.date_range = new_date_range
 
     def get_date_range(self):

--- a/tests/test_DecoratorPattern.py
+++ b/tests/test_DecoratorPattern.py
@@ -19,4 +19,5 @@ def test_sensor_with_cleansing():
     assert sensor_with_cleansing.process_data() == ([datetime(2023, 1, 1, 0, 0), datetime(2023, 1, 2, 0, 0), datetime(2023, 1, 3, 0, 0), datetime(2023, 1, 4, 0, 0)], [22.0, 23.0, 23.0, 23.0])
 
 def test_sensor_with_cleansing_and_prediction():
-    assert sensor_with_cleansing_and_prediction.process_data() == ([datetime(2023, 1, 1, 0, 0), datetime(2023, 1, 2, 0, 0), datetime(2023, 1, 3, 0, 0), datetime(2023, 1, 4, 0, 0)], [22.0, 23.0, 23.0, 23.0], [datetime(2023, 1, 5, 0, 0), datetime(2023, 1, 6, 0, 0), datetime(2023, 1, 7, 0, 0)], [0.0, 0.0, 0.0])
+    assert sensor_with_cleansing_and_prediction.process_data() == ([datetime(2023, 1, 1,  0), datetime(2023, 1, 2, 0, 0), datetime(2023, 1, 3, 0, 0), datetime(2023, 1, 4, 0, 0), datetime(2023, 1, 5, 0, 0), datetime(2023, 1, 6, 0, 0), datetime(2023, 1, 7, 0, 0)], [22.0, 23.0, 23.0, 23.0, 0.0, 0.0, 0.0])
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -20,11 +20,6 @@ def test_update_sensor():
     sensor.set_name("Humidity Sensor")
     sensor.set_description("Measures Humidity")
 
-    with pytest.raises(Exception) as e:
-        sensor.set_value([50])
-
-    assert str(e.value) == "The length of the new value must be equal to the length of the date range"
-
     assert sensor.name == "Humidity Sensor"
     assert sensor.description == "Measures Humidity"
     assert sensor.value == [1,2,3]


### PR DESCRIPTION
Based on the discussion at the end of the day on Tuesday all the features have been added. Please use user testing to evaluate the functionality. You will notice that the charts are only displayed at the bottom of the page. This is due to the front-end formatting and is like that in the main right now, it is not a result of the changes I have made. I will leave it to @Reebs296 to fix that bug in a future PR.