### PR TITLE
fix chart and test_chart

### DIFF
--- a/src/Chart.py
+++ b/src/Chart.py
@@ -1,7 +1,7 @@
 from sensors.sensor import Sensor
 
 class Chart():
-    def __init__(self, sensor: Sensor, AlarmList):
+    def __init__(self, sensor: Sensor):
         self.sensor = sensor
     
     def get_values(self):

--- a/tests/test_Chart.py
+++ b/tests/test_Chart.py
@@ -7,7 +7,6 @@ import pytest
 
 sensor1 = Sensor("Temperature Sensor", "Measures Temperature", [dt.datetime(2020, 1, 1), dt.datetime(2020, 1, 2), dt.datetime(2020, 1, 3), dt.datetime(2020, 1, 4)], [1,2, 3, 10])
 
-@pytest.fixture
 def test_create_chart_instance():
     charter = Chart(sensor1)
     assert charter.sensor == sensor1


### PR DESCRIPTION
found the bug, charts, for some reason required an alarm list when initializing but was never used so it created a bug in the initialization of the chart in the test chart class. also, the test chart class got by the pipeline since it was decorated with pytest.fixture which made the tests not see it. Removing the decorator allows the pipeline to see it and test it. the tests now pass and chart can be used! 
closes #254 